### PR TITLE
Close mongo client before return

### DIFF
--- a/_data/films.js
+++ b/_data/films.js
@@ -15,5 +15,7 @@ async function getFilms() {
   	const films = db.collection('films');
 
 	const query = { "public": true };
-	return await films.find(query).toArray();
+	const filmArray = await films.find(query).toArray();
+	await client.close();
+	return filmArray;
 }


### PR DESCRIPTION
(After installing mongo 😅) I was able to repro Eleventy hanging locally and figured the only "weird" bit was the `async function getFilms`, so I started poking around there.

Commenting it out the whole file allowed 11ty to return properly, so I was pretty sure this was it. I saw that the MongoDB `client` was opened, but never closed, which might explain why 11ty never exited. So I tried closing the client after the data resolves and it seems to have worked.